### PR TITLE
Add DB limit for call records

### DIFF
--- a/cogs/records.py
+++ b/cogs/records.py
@@ -27,18 +27,28 @@ class RecordsCog(commands.Cog):
     async def showRecords(self, ctx: discord.Interaction, tipo: RecordTypes = None):
         await ctx.response.defer()
         if tipo is None or tipo == "Tempo em call":
-            records = getAllVoiceRecords(ctx.guild.id)
+            records = getAllVoiceRecords(ctx.guild.id, limit=10)
             if not records:
                 await ctx.followup.send(content='Nenhum recorde registrado.')
                 return
-            lines = []
-            for record in records:
+
+            embed = discord.Embed(
+                title='Recordes de tempo em call',
+                color=discord.Color.blue(),
+            )
+
+            for index, record in enumerate(records, start=1):
                 member = ctx.guild.get_member(record['user_id'])
                 if member is None:
                     continue
                 duration = str(timedelta(seconds=record['seconds']))
-                lines.append(f'{member.display_name} - {duration}')
-            await ctx.followup.send(content='Recordes de tempo em call:\n' + '\n'.join(lines))
+                embed.add_field(
+                    name=f'{index}. {member.display_name}',
+                    value=duration,
+                    inline=False
+                )
+
+            await ctx.followup.send(embed=embed)
         else:
             await ctx.followup.send(content='Tipo de recorde desconhecido.', ephemeral=True)
 

--- a/core/database.py
+++ b/core/database.py
@@ -1036,15 +1036,16 @@ WHERE user_id = {user_id} AND server_guild_id = {guild_id};"""
     return myresult[0] if myresult else 0
 
 
-def getAllVoiceRecords(guild_id: int):
-    """Retrieve all voice call records for a guild sorted by duration"""
+def getAllVoiceRecords(guild_id: int, limit: int = 10):
+    """Retrieve top voice call records for a guild sorted by duration"""
     mydb = connectToDatabase()
     cursor = mydb.cursor()
     query = f"""SELECT discord_user.discord_user_id, user_records.voice_time
 FROM user_records
 JOIN discord_user ON discord_user.user_id = user_records.user_id
 WHERE user_records.server_guild_id = {guild_id}
-ORDER BY user_records.voice_time DESC;"""
+ORDER BY user_records.voice_time DESC
+LIMIT {limit};"""
     cursor.execute(query)
     myresult = cursor.fetchall()
     endConnection(mydb)


### PR DESCRIPTION
## Summary
- fetch only the top 10 call records directly from the database
- iterate over results without slicing

## Testing
- `python -m py_compile cogs/records.py core/database.py`


------
https://chatgpt.com/codex/tasks/task_e_68670c2a0d808324aa9bcdce344fd01e