### PR TITLE
Refine activity tracker

### DIFF
--- a/cogs/trending.py
+++ b/cogs/trending.py
@@ -1,0 +1,131 @@
+from discord.ext import commands, tasks
+import discord
+from discord import app_commands
+from datetime import datetime, timedelta
+from typing import Literal
+
+from core.time_functions import now
+from core.monthly_activity import (
+    add_time,
+    get_trending_games,
+    get_total_games,
+    get_games_for_months,
+    previous_months,
+    current_month,
+    cleanup_old_weekly_entries,
+)
+from settings import DISCORD_GUILD_ID
+
+class TrendingCog(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.sessions: dict[int, tuple[datetime, str]] = {}
+        super().__init__()
+        self.save_activity.start()
+        self.cleanup_weekly.start()
+
+    def cog_unload(self):
+        self.save_activity.cancel()
+        self.cleanup_weekly.cancel()
+
+    @app_commands.command(name='atividades_em_alta', description='Mostra os jogos mais jogados do mês')
+    async def showTrending(self, ctx: discord.Interaction):
+        await ctx.response.defer()
+        games = get_trending_games()
+        if not games:
+            await ctx.followup.send(content='Nenhuma atividade registrada neste mês.')
+            return
+        sorted_games = sorted(games.items(), key=lambda x: x[1], reverse=True)[:10]
+        embed = discord.Embed(title='Jogos em alta', color=discord.Color.green())
+        for index, (name, seconds) in enumerate(sorted_games, start=1):
+            duration = str(timedelta(seconds=seconds))
+            embed.add_field(name=f'{index}. {name}', value=duration, inline=False)
+        await ctx.followup.send(embed=embed)
+
+    @app_commands.command(name='relatorio_atividades', description='Mostra um relatório de jogos registrados')
+    async def activityReport(
+        self,
+        ctx: discord.Interaction,
+        periodo: Literal[
+            'mes_atual',
+            'ultimo_mes',
+            'ultimos_3_meses',
+            'ultimos_6_meses',
+            'ultimo_ano',
+        ] = 'mes_atual',
+    ):
+        await ctx.response.defer()
+        if periodo == 'mes_atual':
+            months = [current_month()]
+            title = f'Atividades de {months[0]}'
+        elif periodo == 'ultimo_mes':
+            months = previous_months(2)[1:]
+            title = f'Atividades de {months[0]}'
+        elif periodo == 'ultimos_3_meses':
+            months = previous_months(3)
+            title = 'Atividades dos últimos 3 meses'
+        elif periodo == 'ultimos_6_meses':
+            months = previous_months(6)
+            title = 'Atividades dos últimos 6 meses'
+        else:  # ultimo_ano
+            months = previous_months(12)
+            title = 'Atividades do último ano'
+
+        games = get_games_for_months(months)
+
+        if not games:
+            await ctx.followup.send(content='Nenhuma atividade registrada.')
+            return
+
+        sorted_games = sorted(games.items(), key=lambda x: x[1], reverse=True)[:10]
+        embed = discord.Embed(title=title, color=discord.Color.green())
+        for index, (name, seconds) in enumerate(sorted_games, start=1):
+            duration = str(timedelta(seconds=seconds))
+            embed.add_field(name=f'{index}. {name}', value=duration, inline=False)
+        await ctx.followup.send(embed=embed)
+
+    @commands.Cog.listener()
+    async def on_presence_update(self, before: discord.Member, after: discord.Member):
+        before_game = next((a.name for a in before.activities if a.type == discord.ActivityType.playing), None)
+        after_game = next((a.name for a in after.activities if a.type == discord.ActivityType.playing), None)
+        if before_game is None and after_game is not None:
+            self.sessions[after.id] = (now(), after_game)
+        elif before_game is not None and after_game is None:
+            session = self.sessions.pop(after.id, None)
+            if session:
+                start, game_name = session
+                seconds = int((now() - start).total_seconds())
+                add_time(game_name, seconds)
+        elif before_game != after_game:
+            session = self.sessions.pop(after.id, None)
+            if session:
+                start, game_name = session
+                seconds = int((now() - start).total_seconds())
+                add_time(game_name, seconds)
+            if after_game is not None:
+                self.sessions[after.id] = (now(), after_game)
+
+    @tasks.loop(minutes=5)
+    async def save_activity(self):
+        if not self.sessions:
+            return
+        guild = self.bot.get_guild(DISCORD_GUILD_ID)
+        if guild is None:
+            return
+        for user_id, (start, game_name) in list(self.sessions.items()):
+            member = guild.get_member(user_id)
+            if member is None:
+                continue
+            seconds = int((now() - start).total_seconds())
+            if seconds > 0:
+                add_time(game_name, seconds)
+                self.sessions[user_id] = (now(), game_name)
+
+    @tasks.loop(hours=24)
+    async def cleanup_weekly(self):
+        if now().weekday() != 0:
+            return
+        cleanup_old_weekly_entries()
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(TrendingCog(bot))

--- a/core/monthly_activity.py
+++ b/core/monthly_activity.py
@@ -1,0 +1,107 @@
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+from dateutil import relativedelta
+
+from core.database import pooled_connection
+
+
+def current_month() -> str:
+    """Return the current month formatted as YYYY-MM."""
+    return datetime.now().strftime('%Y-%m')
+
+
+def current_week() -> str:
+    """Return the start date of the current week formatted as YYYY-MM-DD."""
+    now = datetime.now()
+    monday = now - timedelta(days=now.weekday())
+    return monday.strftime('%Y-%m-%d')
+
+
+def previous_months(amount: int) -> List[str]:
+    """Return a list of the last ``amount`` months including the current one."""
+    months: List[str] = []
+    now = datetime.now()
+    for i in range(amount):
+        dt = now - relativedelta.relativedelta(months=i)
+        months.append(dt.strftime('%Y-%m'))
+    return months
+
+
+def add_time(game: str, seconds: int, month: str | None = None, week: str | None = None) -> None:
+    """Record play time for a game in the given month and week."""
+    month = month or current_month()
+    week = week or current_week()
+    with pooled_connection() as cursor:
+        sql_month = """
+        INSERT INTO stats_monthly_game_activity (month, game_name, seconds)
+        VALUES (%s, %s, %s)
+        ON DUPLICATE KEY UPDATE seconds = seconds + VALUES(seconds);
+        """
+        cursor.execute(sql_month, (month, game, seconds))
+        sql_week = """
+        INSERT INTO stats_weekly_game_activity (week, game_name, seconds)
+        VALUES (%s, %s, %s)
+        ON DUPLICATE KEY UPDATE seconds = seconds + VALUES(seconds);
+        """
+        cursor.execute(sql_week, (week, game, seconds))
+
+
+def get_trending_games(month: str | None = None) -> Dict[str, int]:
+    """Return a mapping of game names to total seconds for the given month."""
+    month = month or current_month()
+    with pooled_connection() as cursor:
+        sql = """
+        SELECT game_name, seconds
+          FROM stats_monthly_game_activity
+         WHERE month = %s
+         ORDER BY seconds DESC;
+        """
+        cursor.execute(sql, (month,))
+        rows = cursor.fetchall()
+        return {row["game_name"]: row["seconds"] for row in rows}
+
+
+def get_total_games() -> Dict[str, int]:
+    """Return total seconds played for each game across all months."""
+    with pooled_connection() as cursor:
+        sql = """
+        SELECT game_name, SUM(seconds) AS total
+          FROM stats_monthly_game_activity
+         GROUP BY game_name
+         ORDER BY total DESC;
+        """
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+        return {row["game_name"]: row["total"] for row in rows}
+
+
+def get_games_for_months(months: List[str]) -> Dict[str, int]:
+    """Return the total seconds played for the given list of months."""
+    if not months:
+        return {}
+    placeholders = ", ".join(["%s"] * len(months))
+    with pooled_connection() as cursor:
+        sql = f"""
+        SELECT game_name, SUM(seconds) AS total
+          FROM stats_monthly_game_activity
+         WHERE month IN ({placeholders})
+         GROUP BY game_name
+         ORDER BY total DESC;
+        """
+        cursor.execute(sql, months)
+        rows = cursor.fetchall()
+        return {row["game_name"]: row["total"] for row in rows}
+
+
+def cleanup_old_weekly_entries(max_age_weeks: int = 4) -> None:
+    """Delete weekly records older than ``max_age_weeks`` weeks."""
+    threshold = datetime.now() - timedelta(weeks=max_age_weeks)
+    monday = threshold - timedelta(days=threshold.weekday())
+    limit = monday.strftime('%Y-%m-%d')
+    with pooled_connection() as cursor:
+        sql = """
+        DELETE FROM stats_weekly_game_activity
+              WHERE week < %s;
+        """
+        cursor.execute(sql, (limit,))


### PR DESCRIPTION
## Summary
- track monthly/weekly game time in new stats tables
- expand `/relatorio_atividades` to handle custom date ranges
- add weekly cleanup task for old records

## Testing
- `python -m py_compile cogs/trending.py core/monthly_activity.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c252189c48324870b1b5a0896feda