### PR TITLE
Add discord account linking command

### DIFF
--- a/cogs/account.py
+++ b/cogs/account.py
@@ -1,6 +1,6 @@
 from discord import Interaction, Member, app_commands
 from discord.ext import commands
-from core.database import admConnectTelegramAccount
+from core.database import admConnectTelegramAccount, mergeDiscordAccounts
 
 class AccountCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -15,7 +15,15 @@ class AccountCog(commands.Cog):
             return await ctx.followup.send(content='Sua conta foi conectada com sucesso! agora você pode usar os comandos do bot no discord e no telegram', ephemeral=False)
         else:
             return await ctx.followup.send(content='Não foi possível conectar sua conta! você já está conectado?', ephemeral=True)
+
+    @app_commands.command(name='adm-associar_membro', description='Associa dois perfis do discord ao mesmo usuário do banco')
+    async def linkDiscordUsers(self, ctx: Interaction, membro: Member, usuario_existente: Member):
+        await ctx.response.defer()
+        result = mergeDiscordAccounts(ctx.guild.id, membro, usuario_existente)
+        if result:
+            return await ctx.followup.send(content=f'O membro {membro.mention} foi associado ao usuário de {usuario_existente.mention}!', ephemeral=False)
+        else:
+            return await ctx.followup.send(content='Não foi possível associar os membros.', ephemeral=True)
         
         
-async def setup(bot: commands.Bot):
-    await bot.add_cog(AccountCog(bot))
+async def setup(bot: commands.Bot):    await bot.add_cog(AccountCog(bot))


### PR DESCRIPTION
## Summary
- allow linking two Discord accounts to the same user record
- expose new `/adm-associar_membro` command to use this feature
- move all related data when merging discord accounts

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca2fab3208324a1190460b5641b26