### PR TITLE
Add ranking info to profile command

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -82,6 +82,20 @@ class ModerationCog(commands.Cog):
         guild_member = ctx.guild.get_member(member.id)
         memberProfile = getUserInfo(guild_member if guild_member else member, ctx.guild.id)
         profileDescription = generateUserDescription(memberProfile)
+
+        voice_record = getVoiceRecordPosition(ctx.guild.id, member)
+        if voice_record and voice_record["rank"] <= 10:
+            duration = str(timedelta(seconds=voice_record["seconds"]))
+            profileDescription += f"\n**Recorde em call:** {duration} (#{voice_record['rank']})"
+
+        game_record = getGameRecordPosition(
+            ctx.guild.id, member, blacklist=getBlacklistedGames(ctx.guild.id)
+        )
+        if game_record and game_record["rank"] <= 10:
+            duration = str(timedelta(seconds=game_record["seconds"]))
+            game_name = game_record.get("game")
+            game_info = f" - {game_name}" if game_name else ""
+            profileDescription += f"\n**Recorde em jogo:** {duration}{game_info} (#{game_record['rank']})"
         embedUserProfile = discord.Embed(
             color=discord.Color.from_str('#febf10'),
             title='{0} - ID {1:64}'.format(member.name, str(member.id)),

--- a/core/database.py
+++ b/core/database.py
@@ -1546,3 +1546,52 @@ def addGameToBlacklist(guild_id: int, game_name: str) -> bool:
         except mysql.connector.Error as err:
             logging.error(f"Database error occurred: {err}")
             return False
+
+
+def getVoiceRecordPosition(guild_id: int, discord_user: discord.Member | discord.User):
+    """Return a member's voice record rank and value in seconds."""
+    user_id = includeUser(discord_user, guild_id)
+    with pooled_connection() as cursor:
+        cursor.execute(
+            "SELECT voice_time FROM user_records WHERE user_id = %s AND server_guild_id = %s",
+            (user_id, guild_id),
+        )
+        row = cursor.fetchone()
+        if not row or row["voice_time"] is None:
+            return None
+        voice_time = row["voice_time"]
+        cursor.execute(
+            "SELECT COUNT(*) AS better FROM user_records WHERE server_guild_id = %s AND voice_time > %s",
+            (guild_id, voice_time),
+        )
+        rank = cursor.fetchone()["better"] + 1
+        return {"rank": rank, "seconds": voice_time}
+
+
+def getGameRecordPosition(
+    guild_id: int,
+    discord_user: discord.Member | discord.User,
+    blacklist: list[str] | None = None,
+):
+    """Return a member's game record rank, value in seconds and game name."""
+    user_id = includeUser(discord_user, guild_id)
+    with pooled_connection() as cursor:
+        exclusion = ""
+        if blacklist:
+            names = "', '".join(name.replace("'", "\\'") for name in blacklist)
+            exclusion = f" AND game_name NOT IN ('{names}')"
+        cursor.execute(
+            f"SELECT game_time, game_name FROM user_records WHERE user_id = %s AND server_guild_id = %s{exclusion}",
+            (user_id, guild_id),
+        )
+        row = cursor.fetchone()
+        if not row or row["game_time"] is None:
+            return None
+        game_time = row["game_time"]
+        game_name = row["game_name"]
+        cursor.execute(
+            f"SELECT COUNT(*) AS better FROM user_records WHERE server_guild_id = %s{exclusion} AND game_time > %s",
+            (guild_id, game_time),
+        )
+        rank = cursor.fetchone()["better"] + 1
+        return {"rank": rank, "seconds": game_time, "game": game_name}


### PR DESCRIPTION
## Summary
- expose helper functions to determine voice/game record ranking
- show user record details in the profile command if within top 10

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d821135448324a83b5043baf5d5d4