### PR TITLE
Fix user merge cleanup

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -1210,6 +1210,10 @@ def mergeDiscordAccounts(
                 "UPDATE discord_user SET user_id=%s WHERE discord_user_id=%s",
                 (target_user_id, member.id),
             )
+            cursor.execute(
+                "DELETE FROM user_birthday WHERE user_id=%s",
+                (current_user_id,),
+            )
             cursor.execute("DELETE FROM users WHERE id=%s", (current_user_id,))
 
             return True


### PR DESCRIPTION
## Summary
- fix mergeDiscordAccounts to remove leftover birthdays before deleting old user

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d831814b08324b801c28f18db69d5