### PR TITLE
Fix profile data for users outside guild

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -502,7 +502,7 @@ def getUserInfo(user: Union[discord.Member, discord.User], guildId: int, userId:
 
         userToReturn = User(
             id=user_id,
-            discordId=dbUser["discord_user_id"],
+            discordId=user.id,
             username=user.name,
             displayName=getattr(user, 'display_name', user.name),
             memberSince=dbUser["member_since"],

--- a/core/database.py
+++ b/core/database.py
@@ -532,7 +532,7 @@ def getUserInfo(user: Union[discord.Member, discord.User], guildId: int, userId:
         return userToReturn
 
 
-def getAltAccounts(member: discord.Member) -> list[int]:
+def getAltAccounts(member: discord.Member | discord.User) -> list[int]:
     """Return a list of other Discord IDs linked to the same user."""
     user_id = getUserId(member.id)
     if user_id is None:

--- a/core/routine_functions.py
+++ b/core/routine_functions.py
@@ -284,7 +284,7 @@ async def checkTicketsState(bot:commands.Bot):
                         await channel.edit(name=f'{channel.name}-❌')
 
 
-def generateUserDescription(member: User):
+def generateUserDescription(member: User, in_guild: bool = True):
     userDescription = f'## Membro '
     if member.isPartner or member.isVip:
         userDescription += f'VIP' if member.isPartner else ''
@@ -295,8 +295,11 @@ def generateUserDescription(member: User):
         userDescription += f'Comum'
     userDescription += f'\n<@{member.discordId}>'
     userDescription += f'\n**Tipo de VIF:** {member.vipType}' if member.isVip else ''
-    userDescription += f'\n**Entrou em:** {member.memberSince.strftime("%d/%m/%Y")}'
-    userDescription += f'\n**Aprovado em:** {member.approvedAt.strftime("%d/%m/%Y") + (f" (a {(datetime.now()-member.approvedAt).days} dias)" if (datetime.now()-member.approvedAt).days < 45 else "") if member.approvedAt else "Desconhecido" if member.approved==1 else "Não aprovado"}'
+    if in_guild:
+        userDescription += f'\n**Entrou em:** {member.memberSince.strftime("%d/%m/%Y")}'
+        userDescription += f'\n**Aprovado em:** {member.approvedAt.strftime("%d/%m/%Y") + (f" (a {(datetime.now()-member.approvedAt).days} dias)" if (datetime.now()-member.approvedAt).days < 45 else "") if member.approvedAt else "Desconhecido" if member.approved==1 else "Não aprovado"}'
+    else:
+        userDescription += f'\n**Não está no servidor**'
     userDescription += f'\n**Aniversário:** {member.birthday.strftime("%d/%m/%Y")} ({math.floor((datetime.now().date()-member.birthday).days/365.2425)} anos)' if member.birthday != None else ''
     userDescription += f'\n'
     if member.locale or member.coins or member.inventory:


### PR DESCRIPTION
## Summary
- allow getAltAccounts to accept `discord.User`
- always show alt account info and warnings in profile command
- indicate when the user isn't in the server and hide join/approval dates

## Testing
- `pytest -q`
- `python -m py_compile cogs/moderation.py core/database.py core/routine_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_686de6b26a8c8324b3a7a4fc5edef9c0