### PR TITLE
Atualiza cron job de aniversários

### DIFF
--- a/message_services/discord_service.py
+++ b/message_services/discord_service.py
@@ -142,11 +142,10 @@ async def cronJobs30m():
         print('Configurações de níveis não encontradas')
         pass
     
-@tasks.loop(minutes=1)
+@tasks.loop(hours=1)
 async def timeSpecificTasks():
-    """ if now().hour == 0 and now().minute == 0:
-        resetDailyCoins()"""
-    if now().hour == 10 and now().minute == 10:
+    """Executa verificações que dependem de horários específicos."""
+    if now().hour == 12:
         await sendBirthdayMessages(bot)
 
 


### PR DESCRIPTION
## Resumo
- executa verificação de aniversários a cada hora
- envia a mensagem apenas quando for meio-dia

## Testes
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68882dd215888324af6aa512dbe2dcf2