### PR TITLE
Add channel visibility check to profile command

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 from datetime import timedelta, datetime
 from dateutil import relativedelta
 from core.time_functions import now
-from core.database import assignTempRole, getProfileData
+from core.database import assignTempRole, getProfileData, getCommandVisibleChannels
 from core.verifications import verifyDate
 from core.database import *
 from core.time_functions import MONTHS
@@ -77,7 +77,9 @@ class ModerationCog(commands.Cog):
 
     @app_commands.command(name=f'perfil', description=f'Mostra o perfil de um membro')
     async def profile(self, ctx: discord.Interaction, member: discord.User):
-        await ctx.response.defer()
+        visible_channels = getCommandVisibleChannels("perfil")
+        is_visible = ctx.channel.id in visible_channels
+        await ctx.response.defer(ephemeral=not is_visible)
         guild_member = ctx.guild.get_member(member.id)
         memberProfile = getProfileData(ctx.guild.id, guild_member if guild_member else member)
         if not memberProfile:
@@ -103,7 +105,7 @@ class ModerationCog(commands.Cog):
         if guild_member and guild_member.is_timed_out():
             footer_text += '  -  >> DE CASTIGO <<'
         embedUserProfile.set_footer(text=footer_text)
-        await ctx.followup.send(embed=embedUserProfile)
+        await ctx.followup.send(embed=embedUserProfile, ephemeral=not is_visible)
 
 
     @app_commands.command(name=f'registrar_usuario', description=f'Registra um membro')

--- a/core/database.py
+++ b/core/database.py
@@ -146,6 +146,24 @@ def getConfig(guild:discord.Guild):
 
         return config
 
+
+def getCommandVisibleChannels(command_name: str) -> list[int]:
+    """Mocked fetch of channel IDs where a command output is public.
+
+    Parameters
+    ----------
+    command_name: str
+        Name of the command to check.
+
+    Returns
+    -------
+    list[int]
+        Channel IDs in which the command should be visible to everyone.
+    """
+    # TODO: Replace this with a real database query
+    return [753704857290014920, 852932512435011704]
+
+
 def getLevelConfig():
     with pooled_connection() as cursor:
         query = f"""SELECT COLUMN_NAME


### PR DESCRIPTION
## Summary
- mock DB lookup for command-visible channels
- hide `/perfil` output outside allowed channels

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cf2bf34ec8324ac8b3ec8353a952c