### PR TITLE
feat: track moderator in warn logs

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -201,11 +201,12 @@ class ModerationCog(commands.Cog):
         await ctx.response.send_message("Registrando warn...")
         staff_roles = getStaffRoles(ctx.guild)
         if any(role in ctx.user.roles for role in staff_roles):
-            warnings = warnMember(ctx.guild.id, membro, motivo)
+            warnings = warnMember(ctx.guild.id, membro, motivo, ctx.user)
             if warnings:
                 await logWarn(
                     ctx.guild,
                     membro,
+                    ctx.user,
                     motivo,
                     warnings["warningsCount"],
                 )

--- a/core/database.py
+++ b/core/database.py
@@ -1336,16 +1336,17 @@ def deleteTempRole(tempRoleDBId:int):
             print(e)
             return False
 
-def warnMember(guild_id:int, discord_user:discord.Member, reason:str):
+def warnMember(guild_id:int, discord_user:discord.Member, reason:str, applied_by:discord.Member):
     with pooled_connection() as cursor:
         user_id = includeUser(discord_user, guild_id)
+        applied_by_id = includeUser(applied_by, guild_id)
         query = f"""SELECT community_id FROM community_discord WHERE guild_id = '{guild_id}';"""
         cursor.execute(query)
         community_id = cursor.fetchone()["community_id"]
         date = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         try:
-            query = f"""INSERT INTO user_warnings (user_id, community_id, date, reason, expired)
-            VALUES ('{user_id}', '{community_id}', '{date}', '{reason}', FALSE);"""
+            query = f"""INSERT INTO user_warnings (user_id, community_id, date, reason, expired, applied_by)
+            VALUES ('{user_id}', '{community_id}', '{date}', '{reason}', FALSE, '{applied_by_id}');"""
             cursor.execute(query)
             query = f"""SELECT COUNT(*) AS warnings_count FROM user_warnings
     WHERE user_id = '{user_id}'

--- a/core/discord_events.py
+++ b/core/discord_events.py
@@ -54,6 +54,7 @@ async def logProfileChange(bot: discord.Client, guild: discord.Guild, user: disc
 async def logWarn(
     guild: discord.Guild,
     member: discord.abc.User,
+    moderator: discord.abc.User,
     reason: str,
     warnings_count: int,
 ):
@@ -71,13 +72,11 @@ async def logWarn(
         color=discord.Color.orange(),
         timestamp=datetime.utcnow(),
     )
-    embed.add_field(name="Membro", value=f"{member.mention} ({member.id})", inline=False)
-    embed.add_field(name="Motivo", value=reason or "N/A", inline=False)
-    embed.add_field(
-        name="Total de warns",
-        value=str(warnings_count),
-        inline=False,
+    embed.description = (
+        f"{member.mention} ({warnings_count} warns)\n"
+        f"{moderator.mention} - {reason or 'N/A'}"
     )
+    embed.set_footer(text=f"ID: {member.id}")
 
     if isinstance(channel, (discord.TextChannel, discord.Thread)):
         await channel.send(embed=embed)


### PR DESCRIPTION
## Summary
- record moderator user in `user_warnings.applied_by`
- enhance warn logging embed with moderator and warning count details

## Testing
- `python -m py_compile core/database.py core/discord_events.py cogs/moderation.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48dd459f883249d5894af1b778984