### PR TITLE
feat: unify event listing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ BraFurries-Discord is a comprehensive bot packed with features to streamline com
 
 * `novo_evento`: Creates a new community event.
 * `novo_evento_por_usuario`: Allows users to create their own events.
-* `eventos`: Lists all upcoming events.
-* `eventos_por_estado`: Filters events by their location.
+* `eventos`: Lists all upcoming events or filters them by state when provided.
 * `evento`: Shows details of a specific event.
 * `evento_reagendar`: Reschedules an existing event (staff only).
 * `evento_agendar_prox`: Schedules an event for another date (staff only).


### PR DESCRIPTION
## Summary
- consolidate `eventos` and `eventos_por_estado` into one command with optional state filter
- document unified behavior in README
- indicate in the event list header whether a state filter was applied

## Testing
- `python -m py_compile cogs/events.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5b4e6a9c0832482308b311d6c80b7