### PR TITLE
Handle Discord Literal limit by splitting state parameters

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from core.database import includeEvent, getAllEvents, getEventsByState, getAllPendingApprovalEvents, approveEventById
 from core.database import admConnectTelegramAccount, getEventByName, scheduleNextEventDate, rescheduleEventDate
 from core.routine_functions import formatSingleEvent, formatEventList, getLocalId
-from schemas.models.locals import StateAbbrev
+from schemas.models.locals import CommonStateAbbrev, OtherStateAbbrev
 
 
 class EventCog(commands.Cog):
@@ -40,21 +40,109 @@ class EventCog(commands.Cog):
                 return await ctx.followup.send(content=f'O evento **{event_name}** foi registrado com sucesso!', ephemeral=False)
 
     @app_commands.command(name='novo_evento', description='Adiciona um evento ao calendário')
-    @app_commands.describe(estado='Abreviação do estado do evento')
-    async def addEventWithDiscordUser(self, ctx: discord.Interaction, user: discord.Member, estado: StateAbbrev, cidade: str, event_name: str, address: str, price: float, starting_date: str, starting_time: str, ending_date: str, ending_time: str, description: str = None, group_link: str = None, site: str = None, max_price: float = None, event_logo_url: str = None):
-        await EventCog.addEvent(self, ctx, user, estado, cidade, event_name, address, price, starting_date, starting_time, ending_date, ending_time, description, group_link, site, max_price, event_logo_url)
+    @app_commands.describe(estado='Abreviação do estado do evento', outro_estado='Abreviação de estados menos comuns')
+    async def addEventWithDiscordUser(
+        self,
+        ctx: discord.Interaction,
+        user: discord.Member,
+        *,
+        estado: CommonStateAbbrev | None = None,
+        outro_estado: OtherStateAbbrev | None = None,
+        cidade: str,
+        event_name: str,
+        address: str,
+        price: float,
+        starting_date: str,
+        starting_time: str,
+        ending_date: str,
+        ending_time: str,
+        description: str = None,
+        group_link: str = None,
+        site: str = None,
+        max_price: float = None,
+        event_logo_url: str = None,
+    ):
+        state = estado or outro_estado
+        if state is None:
+            return await ctx.response.send_message(content='Você precisa informar um estado.', ephemeral=True)
+        await EventCog.addEvent(
+            self,
+            ctx,
+            user,
+            state,
+            cidade,
+            event_name,
+            address,
+            price,
+            starting_date,
+            starting_time,
+            ending_date,
+            ending_time,
+            description,
+            group_link,
+            site,
+            max_price,
+            event_logo_url,
+        )
 
     @app_commands.command(name='novo_evento_por_usuario', description='Adiciona um evento ao calendário usando um usuário do telegram')
-    @app_commands.describe(estado='Abreviação do estado do evento')
-    async def addEventWithTelegramUser(self, ctx: discord.Interaction, telegram_username: str, estado: StateAbbrev, cidade: str, event_name: str, address: str, price: float, starting_date: str, starting_time: str, ending_date: str, ending_time: str, description: str = None, group_link: str = None, site: str = None, max_price: float = None, event_logo_url: str = None):
-        await EventCog.addEvent(self, ctx, telegram_username, estado, cidade, event_name, address, price, starting_date, starting_time, ending_date, ending_time, description, group_link, site, max_price, event_logo_url)
+    @app_commands.describe(estado='Abreviação do estado do evento', outro_estado='Abreviação de estados menos comuns')
+    async def addEventWithTelegramUser(
+        self,
+        ctx: discord.Interaction,
+        telegram_username: str,
+        *,
+        estado: CommonStateAbbrev | None = None,
+        outro_estado: OtherStateAbbrev | None = None,
+        cidade: str,
+        event_name: str,
+        address: str,
+        price: float,
+        starting_date: str,
+        starting_time: str,
+        ending_date: str,
+        ending_time: str,
+        description: str = None,
+        group_link: str = None,
+        site: str = None,
+        max_price: float = None,
+        event_logo_url: str = None,
+    ):
+        state = estado or outro_estado
+        if state is None:
+            return await ctx.response.send_message(content='Você precisa informar um estado.', ephemeral=True)
+        await EventCog.addEvent(
+            self,
+            ctx,
+            telegram_username,
+            state,
+            cidade,
+            event_name,
+            address,
+            price,
+            starting_date,
+            starting_time,
+            ending_date,
+            ending_time,
+            description,
+            group_link,
+            site,
+            max_price,
+            event_logo_url,
+        )
 
     @app_commands.command(name='eventos', description='Lista todos os eventos registrados')
-    @app_commands.describe(state='Abreviação do estado para filtrar os eventos')
-    async def listEvents(self, ctx: discord.Interaction, state: StateAbbrev | None = None):
+    @app_commands.describe(state='Abreviação do estado para filtrar os eventos', outro_estado='Abreviação de estados menos comuns')
+    async def listEvents(
+        self,
+        ctx: discord.Interaction,
+        state: CommonStateAbbrev | None = None,
+        outro_estado: OtherStateAbbrev | None = None,
+    ):
         await ctx.response.defer()
-        if state:
-            locale_id = await getLocalId(state)
+        selected_state = state or outro_estado
+        if selected_state:
+            locale_id = await getLocalId(selected_state)
             result = getEventsByState(locale_id)
         else:
             result = getAllEvents()
@@ -62,8 +150,8 @@ class EventCog(commands.Cog):
             formattedEvents = formatEventList(result)
             eventsResponse = []
             header = "Aqui estão os próximos eventos registrados"
-            if state:
-                header += f" em {state}"
+            if selected_state:
+                header += f" em {selected_state}"
             else:
                 header += " (sem filtro)"
             for event in formattedEvents:
@@ -77,8 +165,8 @@ class EventCog(commands.Cog):
             for message in eventsResponse:
                 await ctx.followup.send(content=message) if message != eventsResponse[-1] else await ctx.channel.send(content=message)
         else:
-            if state:
-                return await ctx.followup.send(content=f'Não há eventos registrados em {state}... que tal ser o primeiro? :3')
+            if selected_state:
+                return await ctx.followup.send(content=f'Não há eventos registrados em {selected_state}... que tal ser o primeiro? :3')
             return await ctx.followup.send(content=f'Não há eventos registrados... que tal ser o primeiro? :3')
 
     @app_commands.command(name=f'evento', description=f'Mostra os detalhes de um evento')

--- a/schemas/models/locals.py
+++ b/schemas/models/locals.py
@@ -31,10 +31,9 @@ stateNames = {
     "BA":"Bahia",
 }
 
-StateAbbrev = Literal[
+CommonStateAbbrev = Literal[
     "AC",
     "AL",
-    "AP",
     "AM",
     "BA",
     "CE",
@@ -51,7 +50,6 @@ StateAbbrev = Literal[
     "PE",
     "PI",
     "RO",
-    "RR",
     "RJ",
     "RN",
     "RS",
@@ -60,6 +58,13 @@ StateAbbrev = Literal[
     "SE",
     "TO",
 ]
+
+OtherStateAbbrev = Literal[
+    "AP",
+    "RR",
+]
+
+StateAbbrev = CommonStateAbbrev | OtherStateAbbrev
 
 stateLetterCodes = {
     "São Paulo":"SP",

--- a/schemas/models/locals.py
+++ b/schemas/models/locals.py
@@ -32,7 +32,6 @@ stateNames = {
 }
 
 CommonStateAbbrev = Literal[
-    "AC",
     "AL",
     "AM",
     "BA",
@@ -52,6 +51,7 @@ CommonStateAbbrev = Literal[
     "RO",
     "RJ",
     "RN",
+    "RR",
     "RS",
     "SC",
     "SP",
@@ -60,8 +60,8 @@ CommonStateAbbrev = Literal[
 ]
 
 OtherStateAbbrev = Literal[
+    "AC",
     "AP",
-    "RR",
 ]
 
 StateAbbrev = CommonStateAbbrev | OtherStateAbbrev


### PR DESCRIPTION
## Summary
- Split Brazilian state abbreviations into common and uncommon groups to avoid the 25-choice limit
- Update info and event commands to accept common or uncommon states with validation

## Testing
- `python -m py_compile cogs/info.py cogs/events.py schemas/models/locals.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62eb7f7b48324ba260ed490233ffe