### PR TITLE
Restrict mention filtering to AI responses

### DIFF
--- a/core/routine_functions.py
+++ b/core/routine_functions.py
@@ -14,6 +14,12 @@ from datetime import datetime, timedelta, timezone
 timezone_offset = -3.0  # Pacific Standard Time (UTC−08:00)
 def now() -> datetime: return (datetime.now(timezone(timedelta(hours=timezone_offset)))).replace(tzinfo=None)
 
+def sanitize_mentions(content: str) -> str:
+    content = re.sub(r'@everyone', '@​everyone', content, flags=re.IGNORECASE)
+    content = re.sub(r'@here', '@​here', content, flags=re.IGNORECASE)
+    content = re.sub(r'<@&\d+>', '', content)
+    return content
+
 def getServerLevelConfig():
     levelConfig = getLevelConfig(DISCORD_GUILD_ID)
     return levelConfig
@@ -282,7 +288,10 @@ async def handle_ai_response(bot, message: discord.Message):
         if not response or not str(response).strip():
             response = 'Desculpa, deu ruim aqui, não consegui responder agora :c'
 
-        await message.channel.send(response)
+        await message.channel.send(
+            sanitize_mentions(response),
+            allowed_mentions=discord.AllowedMentions(everyone=False, roles=False)
+        )
     await bot.process_commands(message)
 
 

--- a/message_services/discord_service.py
+++ b/message_services/discord_service.py
@@ -18,31 +18,13 @@ import re
 import os
 import sys
 
-DEFAULT_ALLOWED_MENTIONS = discord.AllowedMentions(everyone=False, roles=False)
-
-def sanitize_mentions(content: str) -> str:
-    content = re.sub(r'@everyone', '@​everyone', content, flags=re.IGNORECASE)
-    content = re.sub(r'@here', '@​here', content, flags=re.IGNORECASE)
-    content = re.sub(r'<@&\d+>', '', content)
-    return content
-
-_original_send = discord.abc.Messageable.send
-
-async def send_filtered(self, content=None, *args, **kwargs):
-    if isinstance(content, str):
-        content = sanitize_mentions(content)
-    kwargs.setdefault('allowed_mentions', DEFAULT_ALLOWED_MENTIONS)
-    return await _original_send(self, content=content, *args, **kwargs)
-
-discord.abc.Messageable.send = send_filtered
-
 BIRTHDAY_REGEX = re.compile(r'(\d{1,2})(?:\s?(?:d[eo]|\/|\\|\.)\s?|\s?)(\d{1,2}|(?:janeiro|fevereiro|março|abril|maio|junho|julho|agosto|setembro|outubro|novembro|dezembro))(?:\s?(?:d[eo]|\/|\\|\.)\s?|\s?)(\d{4})')
 MONTHS = ['00','janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho', 'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro']
 
 intents = discord.Intents.default()
 for DISCORD_INTENT in DISCORD_INTENTS:
     setattr(intents, DISCORD_INTENT, True)
-bot = MyBot(config=None,command_prefix=DISCORD_BOT_PREFIX, intents=discord.Intents.all(), allowed_mentions=DEFAULT_ALLOWED_MENTIONS)
+bot = MyBot(config=None,command_prefix=DISCORD_BOT_PREFIX, intents=discord.Intents.all())
 levelConfig = None
 timezone_offset = -3.0  # Pacific Standard Time (UTC−08:00)
 def now() -> datetime: return (datetime.now(timezone(timedelta(hours=timezone_offset)))).replace(tzinfo=None)


### PR DESCRIPTION
## Summary
- remove global mention filtering so non-AI bot messages may use mentions freely
- sanitize and restrict mentions only when sending AI-generated replies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae0b664e608324a027f638f4efa8c1